### PR TITLE
Google IAP auth, healthz endpoint and no compdb to allow mac builds

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,13 +1,13 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@com_grail_bazel_compdb//:aspects.bzl", "compilation_database")
+# load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
 
-compilation_database(
-    name = "compilation_db",
-    targets = [
-        "//src/tools:codesearch",
-        "//src/tools:codesearchtool",
-    ],
-)
+# compilation_database(
+#     name = "compilation_db",
+#     targets = [
+#         "//src/tools:codesearch",
+#         "//src/tools:codesearchtool",
+#     ],
+# )
 
 load("@bazel_gazelle//:def.bzl", "gazelle")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,6 +61,13 @@ git_repository(
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
+load(
+    "//tools/build_defs:go_externals.bzl",
+    "go_externals",
+)
+
+go_externals()
+
 go_rules_dependencies()
 
 go_register_toolchains(version = "1.17.6")
@@ -69,12 +76,6 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
-load(
-    "//tools/build_defs:go_externals.bzl",
-    "go_externals",
-)
-
-go_externals()
 
 http_archive(
     name = "com_github_libgit2",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,11 +84,26 @@ http_archive(
     url = "https://github.com/libgit2/libgit2/archive/v0.27.9.tar.gz",
 )
 
+# http_archive(
+#     name = "com_grail_bazel_compdb",
+#     strip_prefix = "bazel-compilation-database-0.5.2",
+#     urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.5.2.tar.gz"],
+# )
+# load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
+# bazel_compdb_deps()
+
+# git_repository(
+#     name = "com_grail_bazel_compdb",
+#     commit = "2cd8ed39ef726645615ba94fcd265d54b0f0de33",
+#     remote = "https://github.com/grailbio/bazel-compilation-database.git",
+# )
+
 git_repository(
     name = "com_github_grpc_grpc",
-    commit = "591d56e1300b6d11948e1b821efac785a295989c",  # 1.44.0
+    # commit = "591d56e1300b6d11948e1b821efac785a295989c",  # 1.44.0
     remote = "https://github.com/grpc/grpc.git",
-    shallow_since = "1644573434 +0100"
+    tag = "v1.44.0"
+    # shallow_since = "1644573434 +0100"
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
@@ -114,11 +129,6 @@ load("@org_dropbox_rules_node//node:defs.bzl", "node_repositories")
 
 node_repositories()
 
-git_repository(
-    name = "com_grail_bazel_compdb",
-    commit = "7658de071fcd072163c24cc96d78e9891d4d81f5",
-    remote = "https://github.com/grailbio/bazel-compilation-database.git",
-)
 
 git_repository(
     name = "com_google_googletest",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,26 +85,11 @@ http_archive(
     url = "https://github.com/libgit2/libgit2/archive/v0.27.9.tar.gz",
 )
 
-# http_archive(
-#     name = "com_grail_bazel_compdb",
-#     strip_prefix = "bazel-compilation-database-0.5.2",
-#     urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.5.2.tar.gz"],
-# )
-# load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
-# bazel_compdb_deps()
-
-# git_repository(
-#     name = "com_grail_bazel_compdb",
-#     commit = "2cd8ed39ef726645615ba94fcd265d54b0f0de33",
-#     remote = "https://github.com/grailbio/bazel-compilation-database.git",
-# )
-
 git_repository(
     name = "com_github_grpc_grpc",
-    # commit = "591d56e1300b6d11948e1b821efac785a295989c",  # 1.44.0
+    commit = "591d56e1300b6d11948e1b821efac785a295989c",  # 1.44.0
     remote = "https://github.com/grpc/grpc.git",
-    tag = "v1.44.0"
-    # shallow_since = "1644573434 +0100"
+    shallow_since = "1644573434 +0100"
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
@@ -130,6 +115,11 @@ load("@org_dropbox_rules_node//node:defs.bzl", "node_repositories")
 
 node_repositories()
 
+# git_repository(
+#     name = "com_grail_bazel_compdb",
+#     commit = "7658de071fcd072163c24cc96d78e9891d4d81f5",
+#     remote = "https://github.com/grailbio/bazel-compilation-database.git",
+# )
 
 git_repository(
     name = "com_google_googletest",

--- a/cmd/livegrep/livegrep.go
+++ b/cmd/livegrep/livegrep.go
@@ -56,6 +56,11 @@ func main() {
 			WriteKey: os.Getenv("HONEYCOMB_WRITE_KEY"),
 			Dataset:  os.Getenv("HONEYCOMB_DATASET"),
 		},
+		GoogleIAPConfig: config.GoogleIAPConfig{
+			ProjectNumber:    os.Getenv("GOOGLE_IAP_PROJECT_NUMBER"),
+			BackendServiceID: os.Getenv("GOOGLE_IAP_BACKEND_SERVICE_ID"),
+			ProjectID:        os.Getenv("GOOGLE_IAP_PROJECT_ID"),
+		},
 	}
 
 	if *indexConfig != "" {
@@ -89,6 +94,11 @@ func main() {
 
 	if cfg.ReverseProxy {
 		handler = middleware.UnwrapProxyHeaders(handler)
+	}
+
+	if middleware.ShouldEnableGoogleIAP(cfg.GoogleIAPConfig) {
+		handler = middleware.WrapWithIAP(handler, cfg.GoogleIAPConfig)
+		log.Printf("Enabled GoogleIAPAuthMiddleware")
 	}
 
 	http.DefaultServeMux.Handle("/", handler)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -14,6 +14,16 @@ type Honeycomb struct {
 	Dataset  string `json:"dataset"`
 }
 
+type GoogleIAPConfig struct {
+	ProjectNumber string `json:"project_number"`
+
+	// Use BackendServiceID for GKE and GCE
+	BackendServiceID string `json:"backend_service_id"`
+
+	// Use ProjectID for GCE
+	ProjectID string `json:"project_id"`
+}
+
 type Config struct {
 	// Location of the directory containing templates and static
 	// assets. This should point at the "web" directory of the
@@ -26,6 +36,11 @@ type Config struct {
 	} `json:"feedback"`
 
 	GoogleAnalyticsId string `json:"google_analytics_id"`
+
+	// If configured, requests will have their headers
+	// validated to make sure they are coming from IAP
+	GoogleIAPConfig GoogleIAPConfig `json:"google_iap_config"`
+
 	// Should we respect X-Real-Ip, X-Real-Proto, and X-Forwarded-Host?
 	ReverseProxy bool `json:"reverse_proxy"`
 

--- a/server/middleware/BUILD
+++ b/server/middleware/BUILD
@@ -2,7 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["reverse_proxy.go"],
+    srcs = ["reverse_proxy.go", "google_iap.go"],
     importpath = "github.com/livegrep/livegrep/server/middleware",
     visibility = ["//visibility:public"],
+    deps = [
+        "//server/log:go_default_library",
+        "//server/config:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+        # "@org_golang_google_api//idtoken:go_default_library",
+    ],
 )

--- a/server/middleware/BUILD
+++ b/server/middleware/BUILD
@@ -9,6 +9,6 @@ go_library(
         "//server/log:go_default_library",
         "//server/config:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-        # "@org_golang_google_api//idtoken:go_default_library",
+        "@org_golang_google_api//idtoken:go_default_library",
     ],
 )

--- a/server/middleware/google_iap.go
+++ b/server/middleware/google_iap.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"golang.org/x/net/context"
-	// "google.golang.org/api/idtoken"
+	"google.golang.org/api/idtoken"
 
 	"github.com/livegrep/livegrep/server/config"
 	"github.com/livegrep/livegrep/server/log"
@@ -52,14 +52,13 @@ func (h *iapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		aud = fmt.Sprintf("/projects/%s/apps/%s", h.cfg.ProjectNumber, h.cfg.ProjectID)
 	}
 
-	// _, err := idtoken.Validate(ctx, iapJWT, aud)
-	log.Printf(ctx, "got aud: %s and iapJWT: %s\n", aud, iapJWT)
+	_, err := idtoken.Validate(ctx, iapJWT, aud)
 
-	// if err != nil {
-	// 	log.Errorf("idtoken.Validate: %v", err)
-	// 	http.Error(w, "Unauthorized", http.StatusUnauthorized)
-	// 	return
-	// }
+	if err != nil {
+		log.Printf(ctx, "Unauthorized: idtoken.Validate: %v", err)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 
 	h.inner.ServeHTTP(w, r)
 }

--- a/server/middleware/google_iap.go
+++ b/server/middleware/google_iap.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"golang.org/x/net/context"
+	// "google.golang.org/api/idtoken"
+
+	"github.com/livegrep/livegrep/server/config"
+	"github.com/livegrep/livegrep/server/log"
+)
+
+type iapHandler struct {
+	inner http.Handler
+	cfg   *config.GoogleIAPConfig
+}
+
+func ShouldEnableGoogleIAP(cfg config.GoogleIAPConfig) bool {
+	ctx := context.Background()
+	if cfg.ProjectNumber == "" {
+		return false
+	}
+
+	if cfg.BackendServiceID == "" && cfg.ProjectID == "" {
+		log.Printf(ctx, "GoogleIAPConfig: ProjectNumber provided but no BackendServiceID or ProjectID found. Not enabling.")
+		return false
+	}
+
+	if cfg.BackendServiceID != "" && cfg.ProjectID != "" {
+		log.Printf(ctx, "GoogleIAPConfig: BackendServiceID and ProjectID are mutually exclusive. Not enabling.")
+		return false
+	}
+
+	return true
+}
+
+func (h *iapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+
+	// GKE and GCE health checks don't use JWT headers, so skip validation
+	if r.URL.Path == "/healthz" {
+		h.inner.ServeHTTP(w, r)
+		return
+	}
+
+	iapJWT := r.Header.Get("x-goog-iap-jwt-assertion")
+	var aud string
+	if h.cfg.BackendServiceID != "" { // GKE or GCE
+		aud = fmt.Sprintf("/projects/%s/global/backendServices/%s", h.cfg.ProjectNumber, h.cfg.BackendServiceID)
+	} else { // GAE
+		aud = fmt.Sprintf("/projects/%s/apps/%s", h.cfg.ProjectNumber, h.cfg.ProjectID)
+	}
+
+	// _, err := idtoken.Validate(ctx, iapJWT, aud)
+	log.Printf(ctx, "got aud: %s and iapJWT: %s\n", aud, iapJWT)
+
+	// if err != nil {
+	// 	log.Errorf("idtoken.Validate: %v", err)
+	// 	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	// 	return
+	// }
+
+	h.inner.ServeHTTP(w, r)
+}
+
+func WrapWithIAP(h http.Handler, cfg config.GoogleIAPConfig) http.Handler {
+	return &iapHandler{h, &cfg}
+}

--- a/tools/build_defs/go_externals.bzl
+++ b/tools/build_defs/go_externals.bzl
@@ -34,11 +34,11 @@ def _gopkg(repo, commit):
     )
 
 _externals = [
-    _golang_x("net", "d212a1ef2de2f5d441c327b8f26cf3ea3ea9f265"),
-    _golang_x("text", "a9a820217f98f7c8a207ec1e45a874e1fe12c478"),
-    _golang_x("oauth2", "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"),
-    _golang_x("sys", "33540a1f603772f9d4b761f416f5c10dade23e96"),
-    _golang_x("crypto", "4b2356b1ed79e6be3deca3737a3db3d132d2847a"),
+    _golang_x("net", "e204ce36a2ba698f7e949cbd2b13458cf51a8042"),
+    _golang_x("text", "d1c84af989ab0f62cd853b5ae33b1b4db4f1e88b"),
+    _golang_x("oauth2", "d3ed0bb246c8d3c75b63937d9a5eecff9c74d7fe"),
+    _golang_x("sys", "da31bd327af904dd4721b4eefa7c505bb3afd214"),
+    _golang_x("crypto", "5e0467b6c7cee3ce8969a8b584d9e6ab01d074f7"),
     struct(
         name = "org_golang_google_appengine",
         commit = "170382fa85b10b94728989dfcf6cc818b335c952",
@@ -61,9 +61,36 @@ _externals = [
         commit = "f74f0337644653eba7923908a4d7f79a4f3a267b",
         importpath = "google.golang.org/grpc",
     ),
+
+    struct(
+        name = "org_golang_google_api",
+        importpath = "google.golang.org/api",
+        commit = "32bf29c2e17105d5f285adac4531846c57847f11", # v0.50.0
+    ),
+    struct(
+        name = "com_google_cloud_go",
+        importpath = "cloud.google.com/go",
+        commit = "2a43d6d30d7041eb6ed0b305c81dc32c8c42ebc1", # v0.87.0
+    ),
+    struct(
+        name = "io_opencensus_go",
+        importpath = "go.opencensus.io",
+        commit = "49838f207d61097fc0ebb8aeef306913388376ca", #v0.23.0
+    ),
+    struct(
+        name = "com_github_golang_groupcache",
+        importpath = "github.com/golang/groupcache",
+        commit = "41bb18bfe9da5321badc438f91158cd790a33aa3",
+    ),
 ]
 
 def go_externals():
+    go_repository(
+        name = "com_google_cloud_go_compute",
+        importpath = "cloud.google.com/go/compute",
+        sum = "h1:rSUBvAyVwNJ5uQCKNJFMwPtTvJkfN38b6Pvb9zZoqJ8=",
+        version = "v0.1.0",
+    )
     for ext in _externals:
         if hasattr(ext, "vcs"):
             go_repository(


### PR DESCRIPTION
* Add code to check for Google IAP headers
* Add libs for google code
* Comment out `combd` so that builds succeed on mac. Will bring this up later
* Move `go_externals` before `go_rules` and `bazel` deps to minimize conflicts
* Add a `/healthz` endpoint that can be used for a straight health check, irrespective of the codesearch backend being up