### PR TITLE
try a disk cache using the restore_keys trick

### DIFF
--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -21,7 +21,8 @@ test --test_verbose_timeout_warnings
 # build --bes_results_url=https://app.buildbuddy.io/invocation/
 # build --bes_backend=grpcs://cloud.buildbuddy.io
 # build --remote_cache=grpcs://cloud.buildbuddy.io
-common --remote_cache=https://storage.googleapis.com/livegrep-bazel-remote-cache
+# common --remote_cache=https://storage.googleapis.com/livegrep-bazel-remote-cache
+common --disk_cache=~/.cache/bazel
 common --remote_timeout=300s
 common --experimental_remote_cache_async
 common --experimental_remote_merkle_tree_cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,6 @@ jobs:
       # Credit to the tensorboard repo for the cache configuration step
       # https://github.com/tensorflow/tensorboard/blob/master/.github/workflows/ci.yml#L58
       # Plenty of ways to do something similar but I really liked theirs
-      #
       - name: 'Configure remote build cache usage'
         env:
           EVENT_TYPE: ${{ github.event_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,7 @@ jobs:
         run: |
           sed -i 's/build --remote_header=x-buildbuddy-api-key=BUILDBUDDY_API_KEY/build --remote_header=x-buildbuddy-api-key='"$BUILDBUDDY_API_KEY"'/' .bazelrc
           if [ "${EVENT_TYPE}" = pull_request ]; then
-            printf 'Using temporary PR write cache (PR build)\n'
-            sed -i 's/common --remote_upload_local_results=false/common --remote_upload_local_results=true/' .bazelrc
+            printf 'Using read-only cache (PR build)\n'
             exit
           fi
           printf 'Using writable cache\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,10 +47,6 @@ jobs:
           path: ~/.cache/bazel
           key: cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: cache-${{ runner.os }}-
-      - name: print cache size
-        id: stats
-        run: |
-          ls -alh ~/.cache/bazel
       - name: bazel build
         id: build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           sed -i 's/common --remote_upload_local_results=false/common --remote_upload_local_results=true/' .bazelrc
       - name: Initialize bazel cache
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
           key: cache-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,19 @@ jobs:
         run: |
           sed -i 's/build --remote_header=x-buildbuddy-api-key=BUILDBUDDY_API_KEY/build --remote_header=x-buildbuddy-api-key='"$BUILDBUDDY_API_KEY"'/' .bazelrc
           if [ "${EVENT_TYPE}" = pull_request ]; then
-            printf 'Using read-only cache (PR build)\n'
+            printf 'Using temporary PR write cache (PR build)\n'
+            sed -i 's/common --remote_upload_local_results=false/common --remote_upload_local_results=true/' .bazelrc
             exit
           fi
           printf 'Using writable cache\n'
-          creds_file=/tmp/svc_acct_creds.json
-          printf '%s\n' "${GCP_CREDS}" >"${creds_file}"
-          printf '%s\n' >>.bazelrc "common --google_credentials=${creds_file}";
           sed -i 's/common --remote_upload_local_results=false/common --remote_upload_local_results=true/' .bazelrc
+      - name: Initialize bazel cache
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/bazel
+          key: cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: cache-${{ runner.os }}-
       - name: bazel build
         id: build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
       - my_main
+  schedule:
+    # Run in cron every 5 days at midnight to keep the cache warm.
+    # Github prunes caches every 7 days
+    - cron: '0 0 */5 * *'
 
 name: Continuous integration
 
@@ -72,8 +76,6 @@ jobs:
           name: "${{ env.build_output_file_name }}"
           path: "builds/${{ env.build_output_file_name }}.tgz"
           retention-days: 1
-      - name: debug env
-        uses: hmarr/debug-action@v2
       - name: Build images
         # livegrep/livegrep already contains built images that match whats in refs/heads/main - don't rebuild
         if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           retention-days: 1
       - name: Build images
         # livegrep/livegrep already contains built images that match whats in refs/heads/main - don't rebuild
-        if: ${{ github.event_name == 'push' }} && ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
         run: |
           docker build -t $BASE_IMAGE_NAME --file docker/base/Dockerfile --build-arg "livegrep_version=$build_output_file_name"  .
           docker build -t $INDEXER_IMAGE_NAME . --file docker/indexer/Dockerfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,10 @@ jobs:
           path: ~/.cache/bazel
           key: cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: cache-${{ runner.os }}-
+      - name: print cache size
+        id: stats
+        run: |
+          ls -alh ~/.cache/bazel
       - name: bazel build
         id: build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
       # Credit to the tensorboard repo for the cache configuration step
       # https://github.com/tensorflow/tensorboard/blob/master/.github/workflows/ci.yml#L58
       # Plenty of ways to do something similar but I really liked theirs
+      #
       - name: 'Configure remote build cache usage'
         env:
           EVENT_TYPE: ${{ github.event_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           sed -i 's/common --remote_upload_local_results=false/common --remote_upload_local_results=true/' .bazelrc
       - name: Initialize bazel cache
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: ~/.cache/bazel
           key: cache-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,8 @@ jobs:
           name: "${{ env.build_output_file_name }}"
           path: "builds/${{ env.build_output_file_name }}.tgz"
           retention-days: 1
+      - name: debug env
+        uses: hmarr/debug-action@v2
       - name: Build images
         # livegrep/livegrep already contains built images that match whats in refs/heads/main - don't rebuild
         if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
We just switched from BuildBuddy GRPC cache -> GCS HTTP cache, and now we're changing one more time to a "local" gh cache.

We use the `actions/cache` action provided by GitHub to store the Bazel cache, along with a `restore_keys` trick that allows us to write to the cache on every invocation. Bazel builds now take ~30s for repeat builds, and the thing that's slowish is downloading/uploading the cache, which takes ~80% of the CI run time. But combined, the now ~4-5min CI times are much faster than the average remote cache run.