### PR TITLE
dump indexer metrics to file and report them statsd

### DIFF
--- a/cmd/livegrep-metrics-exporter/BUILD
+++ b/cmd/livegrep-metrics-exporter/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "flags.go",
+        "main.go",
+    ],
+    importpath = "github.com/livegrep/livegrep/cmd/livegrep-metrics-exporter",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@in_gopkg_alexcesaro_statsd_v2//:go_default_library"
+    ],
+)
+
+go_binary(
+    name = "livegrep-metrics-exporter",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/livegrep-metrics-exporter/flags.go
+++ b/cmd/livegrep-metrics-exporter/flags.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+// stringMapFlag implements flag.Value and provides the ability to specify multiple, arbitrary
+// key-value parameters, presented as a map of string -> interface{}.
+type stringMapFlag struct {
+	flag.Value
+
+	values map[string]interface{}
+}
+
+func newStringMapFlag() *stringMapFlag {
+	return &stringMapFlag{
+		values: make(map[string]interface{}),
+	}
+}
+
+func (sm *stringMapFlag) Set(value string) error {
+	components := strings.Split(value, "=")
+	if len(components) != 2 {
+		return fmt.Errorf("improperly formatted key-value parameter")
+	}
+
+	sm.values[components[0]] = components[1]
+
+	return nil
+}
+
+func (sm *stringMapFlag) Values() map[string]interface{} {
+	return sm.values
+}
+
+func (sm *stringMapFlag) String() string {
+	var kvPairs []string
+
+	for key, value := range sm.values {
+		kvPairs = append(kvPairs, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	return strings.Join(kvPairs, ",")
+}

--- a/cmd/livegrep-metrics-exporter/main.go
+++ b/cmd/livegrep-metrics-exporter/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/alexcesaro/statsd.v2"
+)
+
+const (
+	envStatsdAddr   = "LIVEGREP_METRICS_STATSD_ADDRESS"
+	envStatsdPrefix = "LIVEGREP_METRICS_STATSD_PREFIX"
+)
+
+var (
+	flagStatsdAddr   = flag.String("statsd-address", os.Getenv(envStatsdAddr), "address URI of statsd listener for metrics export")
+	flagStatsdPrefix = flag.String("statsd-prefix", os.Getenv(envStatsdPrefix), "optional prefix to apply to all metrics")
+	flagMetricsPath  = flag.String("metrics-out", "", "path to the file containing indexing metrics")
+	flagStatsdTags   = newStringMapFlag()
+
+	indexTimeToCompletePattern = regexp.MustCompile("repository[\\s]*indexed[\\s]*in[\\s]*(.*)")
+	metricPattern              = regexp.MustCompile(strings.Join([]string{
+		"([\\w\\.]+)", // Metric name (alphabetic characters and dots)
+		"\\s",         // Separator
+		"(\\d+)",      // Metric value (gauge)
+	}, ""))
+	metricsDumpPattern = regexp.MustCompile("(?s)== begin metrics ==\\s*(.+)\\s== end metrics ==")
+)
+
+func init() {
+	flag.Var(flagStatsdTags, "statsd-tag", "statsd tags to include on all emitted metrics")
+
+	flag.Parse()
+
+	if *flagMetricsPath == "" {
+		log.Fatalf("--metrics-out must be provided\n")
+	}
+
+	if *flagStatsdAddr == "" {
+		panic(fmt.Errorf("no statsd target address specified"))
+	} else {
+		log.Printf("using statsd server: address=%s", *flagStatsdAddr)
+	}
+
+	if *flagStatsdPrefix != "" {
+		log.Printf("using prefix for all metrics: prefix=%s", *flagStatsdPrefix)
+	}
+}
+
+func main() {
+	log.Println("starting livegrep statsd metrics exporter")
+
+	// Stopwatch to track the end-to-end duration required to export metrics
+	start := time.Now()
+
+	// Create a statsd client
+	statsd, err := statsd.New(statsd.Address(*flagStatsdAddr), statsd.Prefix(*flagStatsdPrefix))
+	if err != nil {
+		panic(err)
+	}
+	defer statsd.Close()
+
+	metricsFile, err := os.ReadFile(*flagMetricsPath)
+	if err != nil {
+		panic(err)
+	}
+
+	metricsFileStr := string(metricsFile)
+
+	iTimeToCompleteLine := indexTimeToCompletePattern.FindStringSubmatch(metricsFileStr)
+	if iTimeToCompleteLine == nil {
+		log.Fatal("failed to read time to index line from stdin")
+	}
+
+	metrics := make(map[string]int)
+	timeToIndex, err := time.ParseDuration(string(iTimeToCompleteLine[1]))
+
+	metrics["index.timeToIndex"] = int(timeToIndex.Milliseconds())
+
+	if err != nil {
+		log.Fatalf("failed to parse indexing time %v", err)
+	}
+
+	// Regex-match the metrics dump block
+	dump := metricsDumpPattern.FindStringSubmatch(metricsFileStr)
+	if len(dump) < 2 {
+		panic(fmt.Errorf("failed to parse metrics dump from indexer output"))
+	}
+
+	// Regex-match the metric name and value from each line
+	for _, metricLine := range strings.Split(dump[1], "\n") {
+		metric := metricPattern.FindStringSubmatch(metricLine)
+		if len(metric) < 3 {
+			panic(fmt.Errorf("failed to parse metric name and value: line=%s", metricLine))
+		}
+
+		value, err := strconv.Atoi(metric[2])
+		if err != nil {
+			panic(fmt.Errorf("failed to parse metric value: name=%s value=%s", metric[1], metric[2]))
+		}
+
+		metrics[metric[1]] = value
+	}
+
+	// Report all parsed gauge metrics to statsd
+	for metric, value := range metrics {
+		log.Printf("reporting gauge metric: metric=%s value=%d", metric, value)
+		statsd.Gauge(metric, float64(value))
+	}
+
+	// Report metrics export duration to statsd
+	duration := time.Since(start)
+	log.Printf("completed metrics export: duration=%v", duration)
+	statsd.Timing("export.duration", duration.Milliseconds())
+}

--- a/cmd/livegrep-metrics-exporter/main.go
+++ b/cmd/livegrep-metrics-exporter/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -42,11 +41,11 @@ func init() {
 	flag.Parse()
 
 	if *flagMetricsPath == "" {
-		log.Fatalf("--metrics-out must be provided\n")
+		log.Fatalf("--metrics-out is required. It is the path to the file containing metrics from the indexing run\n")
 	}
 
 	if *flagStatsdAddr == "" {
-		panic(fmt.Errorf("no statsd target address specified"))
+		log.Fatalf("--statsd-address is required. It is the host:port of the StatsD server.\n")
 	} else {
 		log.Printf("using statsd server: address=%s", *flagStatsdAddr)
 	}
@@ -91,7 +90,7 @@ func main() {
 	// Regex-match the metrics dump block
 	dump := metricsDumpPattern.FindStringSubmatch(metricsFileStr)
 	if len(dump) < 2 {
-		panic(fmt.Errorf("failed to parse metrics dump from indexer output"))
+		log.Fatalf("failed to parse metrics dump from indexer output")
 	}
 
 	// Regex-match the metric name and value from each line
@@ -99,12 +98,12 @@ func main() {
 	for _, metricLine := range strings.Split(dump[1], "\n") {
 		metric := metricPattern.FindStringSubmatch(metricLine)
 		if len(metric) < 3 {
-			panic(fmt.Errorf("failed to parse metric name and value: line=%s", metricLine))
+			log.Fatalf("failed to parse metric name and value: line=%s", metricLine)
 		}
 
 		value, err := strconv.Atoi(metric[2])
 		if err != nil {
-			panic(fmt.Errorf("failed to parse metric value: name=%s value=%s", metric[1], metric[2]))
+			log.Fatalf("failed to parse metric value: name=%s value=%s", metric[1], metric[2])
 		}
 
 		metrics[metric[1]] = value

--- a/src/lib/metrics.cc
+++ b/src/lib/metrics.cc
@@ -1,6 +1,8 @@
 #include "metrics.h"
+#include <string.h>
 
 #include <stdlib.h>
+#include <string>
 #include <map>
 #include <mutex>
 
@@ -24,4 +26,21 @@ void metric::dump_all() {
         fprintf(stderr, "%s %ld\n", it->first.c_str(), it->second->val_.load());
     }
     fprintf(stderr, "== end metrics ==\n");
+}
+
+void metric::dump_all_to_file(const std::string &filePath, int elapsedSec, int elapsedUSec) {
+    FILE * pFile; 
+    pFile = fopen(filePath.c_str(), "w");
+    if (pFile == NULL) {
+        std::string errMsg = "Cannot open " + filePath;
+        perror(errMsg.c_str());
+        exit(1);
+    }
+
+    fprintf(pFile, "repository indexed in %d.%06ds\n", elapsedSec, elapsedUSec);
+    fprintf(pFile, "== begin metrics ==\n");
+    for (auto it = metrics->begin(); it != metrics->end(); ++it) {
+        fprintf(pFile, "%s %ld\n", it->first.c_str(), it->second->val_.load());
+    }
+    fprintf(pFile, "== end metrics ==\n");
 }

--- a/src/lib/metrics.h
+++ b/src/lib/metrics.h
@@ -22,6 +22,7 @@ public:
     void dec(long i) {val_ -= i;}
 
     static void dump_all();
+    static void dump_all_to_file(const std::string &path, int elapsedSec, int elapsedUSec);
 
 #ifdef CODESEARCH_SLOWGTOD
     class timer {

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -56,6 +56,7 @@ DEFINE_bool(hot_index_reload, false, "Enable automatic reloads when the index fi
 DEFINE_bool(reuseport, true, "Set SO_REUSEPORT to enable multiple concurrent server instances.");
 DEFINE_int32(max_recv_message_size, 0, "Maximum gRPC receive (inbound) message size in bytes");
 DEFINE_int32(max_send_message_size, 0, "Maximum gRPC send (outbound) message size in bytes");
+DEFINE_string(dump_metrics, "", "Dump indexing metrics to a specified file");
 
 using namespace std;
 using namespace re2;
@@ -140,6 +141,9 @@ void initialize_search(code_searcher *search,
         fprintf(stderr, "repository indexed in %d.%06ds\n",
                 (int)elapsed.tv_sec, (int)elapsed.tv_usec);
         metric::dump_all();
+        if (FLAGS_dump_metrics.size() > 0) {
+            metric::dump_all_to_file(FLAGS_dump_metrics, (int)elapsed.tv_sec, (int)elapsed.tv_usec);
+        }
     } else {
         search->load_index(FLAGS_load_index);
     }


### PR DESCRIPTION
This does 2 main things
* Allows tools/codesearch the ability to dump metrics to a file
* Creates cmd/livegrep-metrics-exporter to read from the metrics file dump and then report things to statsd