### PR TITLE
Styles tweaks

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -209,17 +209,18 @@ a:hover {
 }
 
 .file-group {
-    background: rgba(19, 61, 153, 0.09);   
     margin-bottom: 15px;
     border: solid 1px rgba(0, 0, 0, 0.1);
     border-left: solid 3px #A0D1FA;
 }
 
 .file-group .header {
+    background: rgba(19, 61, 153, 0.09);   
     align-items: center;
     display: flex;
     justify-content: space-between;
     padding: 3px 5px;
+    margin-bottom: 10px;
 }
 
 .file-action-link-separator {
@@ -251,22 +252,33 @@ a:hover {
     background-color: #fff;
 }
 
-.match + .match {
-    border: solid 1px rgba(0, 0, 0, 0.15);
-    margin-top: 5px;
+.file-group .match:last-of-type {
+    padding-bottom: 10px;
 }
 
 .match.clip-before {
     margin-top: 0;
-    border-top: none;
+    border: none;
 }
 
-.match.clip-before .contents {
-    padding-top: 0;
+.match.clip-after {
+    border: none;
 }
 
-.match.clip-after .contents {
-    padding-bottom: 0;
+/* wrap lines within .contents so we can highlight all 
+ * blocks at the same time */
+.match .content-line-wrapper {
+    display: contents;
+}
+
+/* Blank lines are used to space match groups within the 
+ * same file that start/end at different line numbers */
+.match .content-line-wrapper.blank-line > * {
+    background-color: #f6f8fa;
+}
+
+.match .content-line-wrapper:hover > * {
+    background-color: #d0eaf9;
 }
 
 .match .contents {
@@ -275,7 +287,6 @@ a:hover {
     white-space: pre-wrap;
     font-family: "Menlo", "Consolas", "Monaco", monospace;
     font-size: 12px;
-    padding: 10px 5px;
     color: #000;
     margin: 0;
 }
@@ -331,10 +342,6 @@ a:hover {
 .matchlinks {
     opacity: 0.3;
     text-align: right;
-}
-
-.match:hover {
-    background-color: #f5f5f5;
 }
 
 .match:hover .matchlinks {

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -12,6 +12,8 @@ body {
     margin: 0;
     font-family: sans-serif;
     min-height: 100vh;
+
+    --hover-highlight-color: #d0eaf9;
 }
 
 a {
@@ -206,6 +208,13 @@ a:hover {
 
 .file-extensions button {
     margin-left: 4px;
+    background-color: transparent;
+    border: 1px solid black;
+    border-radius: 3px;
+}
+
+.file-extensions button:hover {
+    background-color: var(--hover-highlight-color);
 }
 
 .file-group {
@@ -277,7 +286,7 @@ a:hover {
 }
 
 .match .content-line-wrapper:hover > * {
-    background-color: #d0eaf9;
+    background-color: var(--hover-highlight-color);
 }
 
 .match .contents {

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -311,9 +311,13 @@ a:hover {
 }
 
 .lno-link {
-    color: #3d464d;
+    color: #6e7781;
     padding-right: 1em;
     text-align: right;
+}
+
+.lno-link:hover {
+    color: black;
 }
 
 .lno:before {

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -211,7 +211,6 @@ a:hover {
 .file-group {
     margin-bottom: 15px;
     border: solid 1px rgba(0, 0, 0, 0.1);
-    border-left: solid 3px #A0D1FA;
 }
 
 .file-group .header {

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -175,7 +175,7 @@ var MatchView = Backbone.View.extend({
     return this;
   },
   _renderLno: function(n, isMatch) {
-    var lnoStr = n.toString() + (isMatch ? ":" : "-");
+    var lnoStr = n.toString();
     var classes = ['lno-link'];
     if (isMatch) classes.push('matchlno');
     return h.a({cls: classes.join(' '), href: this.model.url(n)}, [

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -192,19 +192,34 @@ var MatchView = Backbone.View.extend({
     var lines_to_display_before = Math.max(0, ctxBefore.length - (clip_before || 0));
     for (i = 0; i < lines_to_display_before; i ++) {
       ctx_before.unshift(
-        this._renderLno(lno - i - 1, false),
-        h.span([this.model.get('context_before')[i]]),
-        h.span({}, [])
+        h.div({ cls: 'content-line-wrapper' }, [].concat(
+          this._renderLno(lno - i - 1, false),
+          h.span([this.model.get('context_before')[i]]),
+          h.span({}, [])
+        ))
       );
     }
     var lines_to_display_after = Math.max(0, ctxAfter.length - (clip_after || 0));
     for (i = 0; i < lines_to_display_after; i ++) {
       ctx_after.push(
-        this._renderLno(lno + i + 1, false),
-        h.span([this.model.get('context_after')[i]]),
-        h.span({}, [])
+        h.div({ cls: 'content-line-wrapper' }, [].concat(
+          this._renderLno(lno + i + 1, false),
+          h.span([this.model.get('context_after')[i]]),
+          h.span({}, [])
+        ))
       );
     }
+
+    if (this.model.get('add_blank_line')) {
+      ctx_after.push(
+          h.div({ cls: 'content-line-wrapper blank-line' }, [
+            h.span({ cls: 'lno-link' }, ['...']),
+            h.span({ cls: '' }, ['']),
+            h.span({ cls: '' }, [''])
+          ])
+      );
+    };
+
     var line = this.model.get('line');
     var bounds = this.model.get('bounds');
     var pieces = [line.substring(0, bounds[0]),
@@ -229,12 +244,14 @@ var MatchView = Backbone.View.extend({
       h.div({cls: 'contents'}, [].concat(
         ctx_before,
         [
+          h.div({ cls: 'content-line-wrapper' }, [].concat( 
             this._renderLno(lno, true),
             h.span({cls: 'matchline'}, [pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]]),
             h.span({cls: 'matchlinks'}, links)
+          )),
         ],
         ctx_after
-      ))
+      )),
     ]);
 
     return matchElement;
@@ -322,6 +339,7 @@ var FileGroup = Backbone.Model.extend({
       } else {
         previous_match.unset('clip_after');
         this_match.unset('clip_before');
+        previous_match.set('add_blank_line', true);
       }
     }
   }


### PR DESCRIPTION
* removes the '-' and ':' chars from in front of line numbers
* Adds a '...' empty line between matches in a file-group when the line numbers aren't sequential between the matches
* Now individual lines can be hovered with a blue hover color, instead of match groups
* removes the border between sequential matches in a file-group
* removes the blue left-border from file-match groups

All changes are pretty well documented in each commit