### PR TITLE
Nginx performance improvements

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -5,19 +5,23 @@ error_log /dev/stdout;
 daemon off;
 
 events {
-  worker_connections  1024;
+  worker_connections  2048;
 }
 
 http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
-  log_format nelhage '$remote_addr - $remote_user [$time_local] '
-                     'request=$request status=$status body_bytes_sent=$body_bytes_sent '
+  log_format nelhage 'remote_addr=$remote_addr time_local=[$time_local] '
+                     'connection_id=$connection '
+                     'connection_requests=$connection_requests '
+                     'request=$request status=$status '
                      'request_time=$request_time '
                      'upstream_response_time=$upstream_response_time '
                      'upstream_connect_time=$upstream_connect_time '
-                     'upstream_header_time=$upstream_header_time'
+                     'upstream_header_time=$upstream_header_time '
+                     'upstream_bytes_received=$upstream_bytes_received '
+                     'bytes_sent=$bytes_sent '
                      'referer=$http_referer user_agent=$http_user_agent '
                      'host=$host scheme=$scheme';
 
@@ -31,7 +35,18 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
 
-  keepalive_timeout  65;
+  # I THINK GKE IS OVERRIDING THESE FIELDS!
+  # I believe this is the max in Chrome (5m)
+  keepalive_timeout  300s;
+  # we are running on Nginx 1.18.0, where the default is 100
+  # In 1.19.10 onward, the default is 1000
+  keepalive_requests 2000;
+
+  # most searches response sizes will be ~40k, so up the size of the
+  # buffers accordingly (from 8 4K|8K). With large max_matches searches
+  # we have potentially huge responses, but we'll cap the buffer size
+  # at 256kb, which should be more than enough for almost all searches
+  proxy_buffers 8 32k;
 
   gzip  on;
   gzip_http_version 1.0;
@@ -46,23 +61,32 @@ http {
   types_hash_max_size 2048;
   types_hash_bucket_size 64;
 
+  upstream backend {
+       server 127.0.0.1:8910;
+
+    # keep 128 idle conns (max) around
+    keepalive 128;
+
+    # keepalive_timeout/requests are inherited from settings above
+  }
+
   server {
     listen 80 default_server;
 
     if ($http_x_forwarded_proto = "http") {
       return 301 https://$host$request_uri;
     }
-    
+
     location = /healthz {
       access_log off;
       proxy_set_header Host $http_host;
       proxy_set_header X-NginX-Proxy true;
-      proxy_pass http://localhost:8910;
+      proxy_pass http://backend;
       proxy_redirect off;
 
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      proxy_set_header Connection "";
     }
 
     location / {
@@ -73,12 +97,12 @@ http {
     location @proxy {
       proxy_set_header Host $http_host;
       proxy_set_header X-NginX-Proxy true;
-      proxy_pass http://localhost:8910;
+      proxy_pass http://backend;
       proxy_redirect off;
 
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      proxy_set_header Connection "";
     }
   }
 

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -35,12 +35,12 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
 
-  # I THINK GKE IS OVERRIDING THESE FIELDS!
-  # I believe this is the max in Chrome (5m)
-  keepalive_timeout  300s;
+  # https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries
+  # Google Rec for HTTP(S) load balanced things is a keepalive_timeout of 620s
+  keepalive_timeout  620s;
   # we are running on Nginx 1.18.0, where the default is 100
   # In 1.19.10 onward, the default is 1000
-  keepalive_requests 2000;
+  keepalive_requests 10000;
 
   # most searches response sizes will be ~40k, so up the size of the
   # buffers accordingly (from 8 4K|8K). With large max_matches searches
@@ -62,12 +62,10 @@ http {
   types_hash_bucket_size 64;
 
   upstream backend {
-       server 127.0.0.1:8910;
+    server 127.0.0.1:8910;
 
-    # keep 128 idle conns (max) around
-    keepalive 128;
-
-    # keepalive_timeout/requests are inherited from settings above
+    # keep 1024 idle conns (max) around
+    keepalive 1024;
   }
 
   server {


### PR DESCRIPTION
We up the `keepalive` timeout to the GKE/GCE HTTP(S) Ingress recommended and bump the number of requests possible on a single connection, clean up the logging a bit, up the size of the `proxy_buffers` to account for the ~40k response size average and move the go server connection into an upstream block so nginx can keep a pool of upstream connections can be kept by nginx.