### PR TITLE
Automatically update head ref

### DIFF
--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -32,7 +32,7 @@ var (
 	flagStatsdOn      = flag.Bool("send-metrics-to-statsd", false, "Send indexing metrics to StatsD")
 	flagStatsdAddr    = flag.String("statsd-address", "", "address URI of statsd listener for metrics export")
 	flagStatsdPrefix  = flag.String("statsd-prefix", "", "optional prefix to apply to all metrics")
-	flagUpdateHead    = flag.Bool("update-head", true, "update the HEAD reference if it has changed on remote")
+	flagUpdateHead    = flag.Bool("update-head", true, "update the local HEAD ref if it is different than remote. Done when updating already cloned repos.")
 )
 
 // Used to extract the refname from a line like the following:

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -211,28 +211,77 @@ if test "$1" = "get"; then
 fi
 `)
 
+// runs exec.Output() and returns the command output
+func callGit2(program string, args []string, username string, password string) ([]byte, error) {
+	var err error
+	var out []byte
+
+	if username != "" || password != "" {
+		f, err := passwordHelper(username, password, &args)
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(f.Name())
+	}
+
+	for i := 0; i < 3; i++ {
+		cmd := exec.Command("git", args...)
+		if password != "" {
+			r, w, err := os.Pipe()
+			if err != nil {
+				return nil, err
+			}
+
+			cmd.ExtraFiles = []*os.File{r}
+
+			go func() {
+				defer w.Close()
+				w.WriteString(password)
+			}()
+			defer r.Close()
+		}
+		if username != "" {
+			cmd.Env = append(os.Environ(), fmt.Sprintf("LIVEGREP_GITHUB_USERNAME=%s", username))
+		}
+		out, err = cmd.Output()
+		if err == nil {
+			return out, nil
+		}
+	}
+	return nil, fmt.Errorf("%s %v: %s", program, args, err.Error())
+}
+
+func passwordHelper(username string, password string, args *[]string) (*os.File, error) {
+	// If we're given credentials, pass them to git via a
+	// credential helper
+	//
+	// In order to avoid the key hitting the
+	// filesystem, we pass the actual key via a
+	// pipe on fd `3`, and we set the askpass
+	// script to a tiny sh script that just reads
+	// from that pipe.
+	f, err := ioutil.TempFile("", "livegrep-credential-helper")
+	if err != nil {
+		return nil, err
+	}
+	f.WriteString(credentialHelperScript)
+	f.Close()
+
+	os.Chmod(f.Name(), 0700)
+	*args = append([]string{"-c", fmt.Sprintf("credential.helper=%s", f.Name())}, *args...)
+
+	return f, nil
+}
+
 func callGit(program string, args []string, username string, password string) error {
 	var err error
 
 	if username != "" || password != "" {
-		// If we're given credentials, pass them to git via a
-		// credential helper
-		//
-		// In order to avoid the key hitting the
-		// filesystem, we pass the actual key via a
-		// pipe on fd `3`, and we set the askpass
-		// script to a tiny sh script that just reads
-		// from that pipe.
-		f, err := ioutil.TempFile("", "livegrep-credential-helper")
+		f, err := passwordHelper(username, password, &args)
 		if err != nil {
 			return err
 		}
-		f.WriteString(credentialHelperScript)
-		f.Close()
 		defer os.Remove(f.Name())
-
-		os.Chmod(f.Name(), 0700)
-		args = append([]string{"-c", fmt.Sprintf("credential.helper=%s", f.Name())}, args...)
 	}
 
 	for i := 0; i < 3; i++ {
@@ -306,40 +355,55 @@ func checkoutOne(r *config.RepoSpec) error {
 		args = append(args, fmt.Sprintf("--depth=%d", r.CloneOptions.Depth))
 	}
 	err = callGit("git", args, username, password)
-	if err != nil || !(*flagUpdateHead) {
-		return err
-	}
-
-	currHead, err := exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD").Output() // git symbolic-ref HEAD
 	if err != nil {
 		return err
 	}
-	// Now get the remote head
-	// Stand in use exec.Command until we refactor callGit to also pass output back
 
-	// output
-	// ref: refs/heads/good_main_2     HEAD
-	// 0666a519f94b8500ab6f14bdf7c9c2e5ca7d5821        HEAD
+	if !(*flagUpdateHead) {
+		return nil
+	}
 
-	remoteOut, err := exec.Command("git", "--git-dir", r.Path, "ls-remote", "--symref", "origin", "HEAD").Output()
+	// We check and update (if needed) the HEAD ref to avoid scenarios where
+	// a remote repo has changed it's head (like a default branch rename/change).
+	// git fetch won't do this, at least not on the mirror clones we use.
+	// See https://public-inbox.org/git/CANWRddPDhM1g6rtu-a2a=EogXD_hOFwSDsgMCbVvB7dibMaEqw@mail.gmail.com/T/#t
+	// for confirmation on this approach from the Git folks.
+	//
+	// To update the HEAD ref we do the following:
+	// 1. Get the current local head ref	- (git symbolic-ref HEAD)
+	// 2. Get the remote head ref			- (git ls-remote --symref origin HEAD)
+	// 3. Compare them. If outdated, update the local to match remote - (git symbolic-ref HEAD new_ref)
+	// The whole process takes around ~1.5s per repo, so if you have many repos to update you may want to increase
+	// the number of workers, or only use the -update-head option periodically.
+	currHeadOut, err := exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD").Output()
 	if err != nil {
 		return err
 	}
+	currHead := strings.TrimSpace(string(currHeadOut))
+
+	args2 := []string{"--git-dir", r.Path, "ls-remote", "--symref", "origin", "HEAD"}
+	remoteOut, err := callGit2("git", args2, username, password)
+	if err != nil {
+		return err
+	}
+
 	submatches := remoteHeadRefExtractorReg.FindStringSubmatch(string(remoteOut))
 	if len(submatches) == 1 {
 		return errors.New("could not parse ls-remote --symref origin HEAD output")
 	}
-	remoteHead := submatches[1]
+	remoteHead := strings.TrimSpace(submatches[1])
 
-	// use .Compare?
-	if string(currHead) != remoteHead {
-		log.Printf("remote HEAD: %s does not match local HEAD: %s. Attempting to fix...\n", remoteHead, currHead)
-		// git symbolic-ref HEAD refs/heads/good_main_2
-		if err = exec.Command("git", "--git-dir", r.Path, " symbolic-ref", "HEAD", remoteHead).Run(); err != nil {
+	if currHead != remoteHead {
+		log.Printf("%s: remote HEAD: %s does not match local HEAD: %s. Attempting to fix...\n", r.Name, remoteHead, currHead)
+
+		// update the HEAD ref
+		err = exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD", remoteHead).Run()
+		if err != nil {
+			log.Printf("error setting symbolic ref. %v\n", err)
 			return err
-		} else {
-			log.Printf("done.\n")
 		}
+
+		log.Printf("%s: HEAD update done.\n")
 	}
 
 	return nil

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -32,7 +32,7 @@ var (
 	flagStatsdOn      = flag.Bool("send-metrics-to-statsd", false, "Send indexing metrics to StatsD")
 	flagStatsdAddr    = flag.String("statsd-address", "", "address URI of statsd listener for metrics export")
 	flagStatsdPrefix  = flag.String("statsd-prefix", "", "optional prefix to apply to all metrics")
-	flagUpdateHead    = flag.Bool("update-head", false, "update the HEAD reference if it has changed on remote")
+	flagUpdateHead    = flag.Bool("update-head", true, "update the HEAD reference if it has changed on remote")
 )
 
 var (
@@ -214,73 +214,6 @@ fi
 // calls cmd.Run() if returnOutput is false
 // and cmd.Output() otherwise
 // always returns an out []byte, but it will always be nill if returnOutput is false
-func callGitAsync(program string, args []string, username string, password string, outBuff *[]byte, outErr *error, wg *sync.WaitGroup, returnOutput bool) {
-	defer wg.Done()
-	var err error
-	var out []byte
-
-	if username != "" || password != "" {
-		// If we're given credentials, pass them to git via a
-		// credential helper
-		//
-		// In order to avoid the key hitting the
-		// filesystem, we pass the actual key via a
-		// pipe on fd `3`, and we set the askpass
-		// script to a tiny sh script that just reads
-		// from that pipe.
-		f, err := ioutil.TempFile("", "livegrep-credential-helper")
-		if err != nil {
-			*outErr = err
-			return
-		}
-		f.WriteString(credentialHelperScript)
-		f.Close()
-		defer os.Remove(f.Name())
-
-		os.Chmod(f.Name(), 0700)
-		args = append([]string{"-c", fmt.Sprintf("credential.helper=%s", f.Name())}, args...)
-	}
-
-	for i := 0; i < 3; i++ {
-		cmd := exec.Command("git", args...)
-		if !returnOutput {
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-		}
-		if password != "" {
-			r, w, err := os.Pipe()
-			if err != nil {
-				*outErr = err
-				return
-			}
-
-			cmd.ExtraFiles = []*os.File{r}
-
-			go func() {
-				defer w.Close()
-				w.WriteString(password)
-			}()
-			defer r.Close()
-		}
-		if username != "" {
-			cmd.Env = append(os.Environ(), fmt.Sprintf("LIVEGREP_GITHUB_USERNAME=%s", username))
-		}
-		if !returnOutput {
-			err = cmd.Run()
-		} else {
-			out, err = cmd.Output()
-		}
-		if err == nil {
-			*outBuff = out
-			*outErr = nil
-			return
-		}
-	}
-
-	*outBuff = nil
-	*outErr = fmt.Errorf("%s %v: %s", program, args, err.Error())
-}
-
 func callGit(program string, args []string, username string, password string, returnOutput bool) ([]byte, error) {
 	var err error
 	var out []byte
@@ -406,17 +339,27 @@ func checkoutOne(r *config.RepoSpec) error {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	var out1, remoteOut []byte
+	var remoteOut []byte
 	var err1, err2 error
 	args2 := []string{"--git-dir", r.Path, "ls-remote", "--symref", "origin", "HEAD"}
 
-	go callGitAsync("git", args, username, password, &out1, &err1, &wg, false)      // git fetch -p
-	go callGitAsync("git", args2, username, password, &remoteOut, &err2, &wg, true) // git ls-remote --symref origin HEAD
+	// git fetch -p
+	go func(outErr *error, wg *sync.WaitGroup) {
+		defer wg.Done()
+		_, *outErr = callGit("git", args, username, password, false)
+	}(&err1, &wg)
+
+	// git ls-remote --symref origin HEAD
+	go func(outBuff *[]byte, outErr *error, wg *sync.WaitGroup) {
+		defer wg.Done()
+		*outBuff, *outErr = callGit("git", args2, username, password, true)
+	}(&remoteOut, &err2, &wg)
+
 	wg.Wait()
 
 	// Brute concat the errors always
 	if err1 != nil || err2 != nil {
-		return fmt.Errorf("%w; %w", err1, err2)
+		return fmt.Errorf("fetch err: %w; ls-remote err: %w", err1, err2)
 	}
 
 	currHeadOut, err := exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD").Output()
@@ -431,19 +374,19 @@ func checkoutOne(r *config.RepoSpec) error {
 	}
 	remoteHead := strings.TrimSpace(submatches[1])
 
-	if currHead != remoteHead {
-		log.Printf("%s: remote HEAD: %s does not match local HEAD: %s. Attempting to fix...\n", r.Name, remoteHead, currHead)
-
-		// update the HEAD ref
-		err = exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD", remoteHead).Run()
-		if err != nil {
-			log.Printf("error setting symbolic ref. %v\n", err)
-			return err
-		}
-
-		log.Printf("%s: HEAD update done.\n")
+	if currHead == remoteHead { // nothing to do
+		return nil
 	}
 
+	log.Printf("%s: remote HEAD: %s does not match local HEAD: %s. Attempting to fix...\n", r.Name, remoteHead, currHead)
+
+	// update the HEAD ref
+	if err = exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD", remoteHead).Run(); err != nil {
+		log.Printf("%s: error setting symbolic ref. %v\n", r.Name, err)
+		return err
+	}
+
+	log.Printf("%s: HEAD update done.\n", r.Name)
 	return nil
 }
 

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -35,11 +35,9 @@ var (
 	flagUpdateHead    = flag.Bool("update-head", true, "update the HEAD reference if it has changed on remote")
 )
 
-var (
-	// Uses to extract the refname from a line like the following:
-	// ref: refs/heads/good_main_2     HEAD
-	remoteHeadRefExtractorReg = regexp.MustCompile("ref:\\s*([^\\s]*)\\s*HEAD")
-)
+// Used to extract the refname from a line like the following:
+// ref: refs/heads/good_main_2     HEAD
+var remoteHeadRefExtractorReg = regexp.MustCompile("ref:\\s*([^\\s]*)\\s*HEAD")
 
 func main() {
 	flag.Parse()

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -30,6 +32,13 @@ var (
 	flagStatsdOn      = flag.Bool("send-metrics-to-statsd", false, "Send indexing metrics to StatsD")
 	flagStatsdAddr    = flag.String("statsd-address", "", "address URI of statsd listener for metrics export")
 	flagStatsdPrefix  = flag.String("statsd-prefix", "", "optional prefix to apply to all metrics")
+	flagUpdateHead    = flag.Bool("update-head", false, "update the HEAD reference if it has changed on remote")
+)
+
+var (
+	// Uses to extract the refname from a line like the following:
+	// ref: refs/heads/good_main_2     HEAD
+	remoteHeadRefExtractorReg = regexp.MustCompile("ref:\\s*([^\\s]*)\\s*HEAD")
 )
 
 func main() {
@@ -296,7 +305,44 @@ func checkoutOne(r *config.RepoSpec) error {
 	if r.CloneOptions != nil && r.CloneOptions.Depth != 0 {
 		args = append(args, fmt.Sprintf("--depth=%d", r.CloneOptions.Depth))
 	}
-	return callGit("git", args, username, password)
+	err = callGit("git", args, username, password)
+	if err != nil || !(*flagUpdateHead) {
+		return err
+	}
+
+	currHead, err := exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD").Output() // git symbolic-ref HEAD
+	if err != nil {
+		return err
+	}
+	// Now get the remote head
+	// Stand in use exec.Command until we refactor callGit to also pass output back
+
+	// output
+	// ref: refs/heads/good_main_2     HEAD
+	// 0666a519f94b8500ab6f14bdf7c9c2e5ca7d5821        HEAD
+
+	remoteOut, err := exec.Command("git", "--git-dir", r.Path, "ls-remote", "--symref", "origin", "HEAD").Output()
+	if err != nil {
+		return err
+	}
+	submatches := remoteHeadRefExtractorReg.FindStringSubmatch(string(remoteOut))
+	if len(submatches) == 1 {
+		return errors.New("could not parse ls-remote --symref origin HEAD output")
+	}
+	remoteHead := submatches[1]
+
+	// use .Compare?
+	if string(currHead) != remoteHead {
+		log.Printf("remote HEAD: %s does not match local HEAD: %s. Attempting to fix...\n", remoteHead, currHead)
+		// git symbolic-ref HEAD refs/heads/good_main_2
+		if err = exec.Command("git", "--git-dir", r.Path, " symbolic-ref", "HEAD", remoteHead).Run(); err != nil {
+			return err
+		} else {
+			log.Printf("done.\n")
+		}
+	}
+
+	return nil
 }
 
 func reloadBackend(addr string) error {

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -211,21 +211,40 @@ if test "$1" = "get"; then
 fi
 `)
 
-// runs exec.Output() and returns the command output
-func callGit2(program string, args []string, username string, password string) ([]byte, error) {
+// calls cmd.Run() if returnOutput is false
+// and cmd.Output() otherwise
+// always returns an out []byte, but it will always be nill if returnOutput is false
+func callGit(program string, args []string, username string, password string, returnOutput bool) ([]byte, error) {
 	var err error
 	var out []byte
 
 	if username != "" || password != "" {
-		f, err := passwordHelper(username, password, &args)
+		// If we're given credentials, pass them to git via a
+		// credential helper
+		//
+		// In order to avoid the key hitting the
+		// filesystem, we pass the actual key via a
+		// pipe on fd `3`, and we set the askpass
+		// script to a tiny sh script that just reads
+		// from that pipe.
+		f, err := ioutil.TempFile("", "livegrep-credential-helper")
 		if err != nil {
 			return nil, err
 		}
+		f.WriteString(credentialHelperScript)
+		f.Close()
 		defer os.Remove(f.Name())
+
+		os.Chmod(f.Name(), 0700)
+		args = append([]string{"-c", fmt.Sprintf("credential.helper=%s", f.Name())}, args...)
 	}
 
 	for i := 0; i < 3; i++ {
 		cmd := exec.Command("git", args...)
+		if !returnOutput {
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		}
 		if password != "" {
 			r, w, err := os.Pipe()
 			if err != nil {
@@ -243,73 +262,16 @@ func callGit2(program string, args []string, username string, password string) (
 		if username != "" {
 			cmd.Env = append(os.Environ(), fmt.Sprintf("LIVEGREP_GITHUB_USERNAME=%s", username))
 		}
-		out, err = cmd.Output()
+		if !returnOutput {
+			err = cmd.Run()
+		} else {
+			out, err = cmd.Output()
+		}
 		if err == nil {
 			return out, nil
 		}
 	}
 	return nil, fmt.Errorf("%s %v: %s", program, args, err.Error())
-}
-
-func passwordHelper(username string, password string, args *[]string) (*os.File, error) {
-	// If we're given credentials, pass them to git via a
-	// credential helper
-	//
-	// In order to avoid the key hitting the
-	// filesystem, we pass the actual key via a
-	// pipe on fd `3`, and we set the askpass
-	// script to a tiny sh script that just reads
-	// from that pipe.
-	f, err := ioutil.TempFile("", "livegrep-credential-helper")
-	if err != nil {
-		return nil, err
-	}
-	f.WriteString(credentialHelperScript)
-	f.Close()
-
-	os.Chmod(f.Name(), 0700)
-	*args = append([]string{"-c", fmt.Sprintf("credential.helper=%s", f.Name())}, *args...)
-
-	return f, nil
-}
-
-func callGit(program string, args []string, username string, password string) error {
-	var err error
-
-	if username != "" || password != "" {
-		f, err := passwordHelper(username, password, &args)
-		if err != nil {
-			return err
-		}
-		defer os.Remove(f.Name())
-	}
-
-	for i := 0; i < 3; i++ {
-		cmd := exec.Command("git", args...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if password != "" {
-			r, w, err := os.Pipe()
-			if err != nil {
-				return err
-			}
-
-			cmd.ExtraFiles = []*os.File{r}
-
-			go func() {
-				defer w.Close()
-				w.WriteString(password)
-			}()
-			defer r.Close()
-		}
-		if username != "" {
-			cmd.Env = append(os.Environ(), fmt.Sprintf("LIVEGREP_GITHUB_USERNAME=%s", username))
-		}
-		if err = cmd.Run(); err == nil {
-			return nil
-		}
-	}
-	return fmt.Errorf("%s %v: %s", program, args, err.Error())
 }
 
 func checkoutOne(r *config.RepoSpec) error {
@@ -343,7 +305,8 @@ func checkoutOne(r *config.RepoSpec) error {
 			args = append(args, fmt.Sprintf("--depth=%d", r.CloneOptions.Depth))
 		}
 		args = append(args, remote, r.Path)
-		return callGit("git", args, username, password)
+		_, err = callGit("git", args, username, password, false)
+		return err
 	}
 
 	if err := exec.Command("git", "-C", r.Path, "remote", "set-url", "origin", remote).Run(); err != nil {
@@ -354,7 +317,8 @@ func checkoutOne(r *config.RepoSpec) error {
 	if r.CloneOptions != nil && r.CloneOptions.Depth != 0 {
 		args = append(args, fmt.Sprintf("--depth=%d", r.CloneOptions.Depth))
 	}
-	err = callGit("git", args, username, password)
+
+	_, err = callGit("git", args, username, password, false)
 	if err != nil {
 		return err
 	}
@@ -382,7 +346,7 @@ func checkoutOne(r *config.RepoSpec) error {
 	currHead := strings.TrimSpace(string(currHeadOut))
 
 	args2 := []string{"--git-dir", r.Path, "ls-remote", "--symref", "origin", "HEAD"}
-	remoteOut, err := callGit2("git", args2, username, password)
+	remoteOut, err := callGit("git", args2, username, password, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -214,6 +214,73 @@ fi
 // calls cmd.Run() if returnOutput is false
 // and cmd.Output() otherwise
 // always returns an out []byte, but it will always be nill if returnOutput is false
+func callGitAsync(program string, args []string, username string, password string, outBuff *[]byte, outErr *error, wg *sync.WaitGroup, returnOutput bool) {
+	defer wg.Done()
+	var err error
+	var out []byte
+
+	if username != "" || password != "" {
+		// If we're given credentials, pass them to git via a
+		// credential helper
+		//
+		// In order to avoid the key hitting the
+		// filesystem, we pass the actual key via a
+		// pipe on fd `3`, and we set the askpass
+		// script to a tiny sh script that just reads
+		// from that pipe.
+		f, err := ioutil.TempFile("", "livegrep-credential-helper")
+		if err != nil {
+			*outErr = err
+			return
+		}
+		f.WriteString(credentialHelperScript)
+		f.Close()
+		defer os.Remove(f.Name())
+
+		os.Chmod(f.Name(), 0700)
+		args = append([]string{"-c", fmt.Sprintf("credential.helper=%s", f.Name())}, args...)
+	}
+
+	for i := 0; i < 3; i++ {
+		cmd := exec.Command("git", args...)
+		if !returnOutput {
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		}
+		if password != "" {
+			r, w, err := os.Pipe()
+			if err != nil {
+				*outErr = err
+				return
+			}
+
+			cmd.ExtraFiles = []*os.File{r}
+
+			go func() {
+				defer w.Close()
+				w.WriteString(password)
+			}()
+			defer r.Close()
+		}
+		if username != "" {
+			cmd.Env = append(os.Environ(), fmt.Sprintf("LIVEGREP_GITHUB_USERNAME=%s", username))
+		}
+		if !returnOutput {
+			err = cmd.Run()
+		} else {
+			out, err = cmd.Output()
+		}
+		if err == nil {
+			*outBuff = out
+			*outErr = nil
+			return
+		}
+	}
+
+	*outBuff = nil
+	*outErr = fmt.Errorf("%s %v: %s", program, args, err.Error())
+}
+
 func callGit(program string, args []string, username string, password string, returnOutput bool) ([]byte, error) {
 	var err error
 	var out []byte
@@ -318,13 +385,10 @@ func checkoutOne(r *config.RepoSpec) error {
 		args = append(args, fmt.Sprintf("--depth=%d", r.CloneOptions.Depth))
 	}
 
-	_, err = callGit("git", args, username, password, false)
-	if err != nil {
-		return err
-	}
-
+	// Call git-fetch and finish
 	if !(*flagUpdateHead) {
-		return nil
+		_, err = callGit("git", args, username, password, false)
+		return err
 	}
 
 	// We check and update (if needed) the HEAD ref to avoid scenarios where
@@ -334,22 +398,32 @@ func checkoutOne(r *config.RepoSpec) error {
 	// for confirmation on this approach from the Git folks.
 	//
 	// To update the HEAD ref we do the following:
-	// 1. Get the current local head ref	- (git symbolic-ref HEAD)
-	// 2. Get the remote head ref			- (git ls-remote --symref origin HEAD)
+	// 1. Get the remote head ref			- (git ls-remote --symref origin HEAD)
+	// 2. Get the current local head ref	- (git symbolic-ref HEAD)
 	// 3. Compare them. If outdated, update the local to match remote - (git symbolic-ref HEAD new_ref)
-	// The whole process takes around ~1.5s per repo, so if you have many repos to update you may want to increase
-	// the number of workers, or only use the -update-head option periodically.
+	// We use goroutines to call `git fetch -p` and `git ls-remote --symref origin HEAD` in "parallel"
+	// becase they each take ~1.5s.
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	var out1, remoteOut []byte
+	var err1, err2 error
+	args2 := []string{"--git-dir", r.Path, "ls-remote", "--symref", "origin", "HEAD"}
+
+	go callGitAsync("git", args, username, password, &out1, &err1, &wg, false)      // git fetch -p
+	go callGitAsync("git", args2, username, password, &remoteOut, &err2, &wg, true) // git ls-remote --symref origin HEAD
+	wg.Wait()
+
+	// Brute concat the errors always
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("%w; %w", err1, err2)
+	}
+
 	currHeadOut, err := exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD").Output()
 	if err != nil {
 		return err
 	}
 	currHead := strings.TrimSpace(string(currHeadOut))
-
-	args2 := []string{"--git-dir", r.Path, "ls-remote", "--symref", "origin", "HEAD"}
-	remoteOut, err := callGit("git", args2, username, password, true)
-	if err != nil {
-		return err
-	}
 
 	submatches := remoteHeadRefExtractorReg.FindStringSubmatch(string(remoteOut))
 	if len(submatches) == 1 {

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -51,6 +51,7 @@ var (
 	flagMaxConcurrentGHRequests = flag.Int("max-concurrent-gh-requests", 1, "Applied per org/user. If fetching 2 orgs, you will have 2x{yourInput} network calls possible at a time")
 	flagNoIndex                 = flag.Bool("no-index", false, "Skip indexing after writing config and fetching")
 	flagOnlyWriteConfig         = flag.Bool("only-write-config", false, "Skip fetching+indexing after writing config")
+	flagUpdateHead              = flag.Bool("update-head", true, "update the local HEAD ref if it is different than remote. Done when updating already cloned repos.")
 
 	flagRepos = stringList{}
 	flagOrgs  = stringList{}
@@ -162,6 +163,9 @@ func main() {
 	}
 	if *flagSkipMissing {
 		args = append(args, "--skip-missing")
+	}
+	if !(*flagUpdateHead) { // only include when false, since true by default
+		args = append(args, "--update-head=false")
 	}
 	args = append(args, configPath)
 


### PR DESCRIPTION
This PR introduces a way for `fetch-reindex` to automatically update the `HEAD` ref of a locally cloned mirror repo if it is out of date with the remote.

This solves an issue when an already cloned repo has a change to it's `HEAD` ref. Such as the ref being renamed. Think GitHub default branch changing. Previously, this would have caused the repo to be skipped during indexing, since (when indexing by `HEAD`) we use libgit2's version of `git rev-parse HEAD^0` to get the latest commit hash. If the `HEAD` on the remote is different than the local, this fails and so the indexer skips the repo. See https://github.com/livegrep/livegrep/issues/293

See the comments in the code for how we accomplish this.