### PR TITLE
Accept larger messages from the backend w/ gRPC

### DIFF
--- a/server/backend.go
+++ b/server/backend.go
@@ -43,21 +43,21 @@ type Backend struct {
 	Up         *Availability
 }
 
-func NewBackend(bk *config.Backend) (*Backend, error) {
+func NewBackend(be *config.Backend) (*Backend, error) {
 	opts := []grpc.DialOption{grpc.WithInsecure()}
-	if bk.MaxMessageSize == 0 {
-		bk.MaxMessageSize = 10 << 20 // default to 10MiB
+	if be.MaxMessageSize == 0 {
+		be.MaxMessageSize = 10 << 20 // default to 10MiB
 	}
-	opts = append(opts, grpc.MaxCallRecvMsgSize(bk.MaxMessageSize))
+	opts = append(opts, grpc.MaxCallRecvMsgSize(be.MaxMessageSize))
 
-	client, err := grpc.Dial(bk.Addr, opts...)
+	client, err := grpc.Dial(be.Addr, opts...)
 	if err != nil {
 		return nil, err
 	}
 	bk := &Backend{
-		Id:         bk.Id,
-		Addr:       bk.Addr,
-		I:          &I{Name: bk.Id},
+		Id:         be.Id,
+		Addr:       be.Addr,
+		I:          &I{Name: be.Id},
 		Codesearch: pb.NewCodeSearchClient(client),
 		Up:         &Availability{},
 	}

--- a/server/backend.go
+++ b/server/backend.go
@@ -48,7 +48,7 @@ func NewBackend(be config.Backend) (*Backend, error) {
 	if be.MaxMessageSize == 0 {
 		be.MaxMessageSize = 10 << 20 // default to 10MiB
 	}
-	opts = append(opts, grpc.MaxCallRecvMsgSize(be.MaxMessageSize))
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(be.MaxMessageSize)))
 
 	client, err := grpc.Dial(be.Addr, opts...)
 	if err != nil {

--- a/server/backend.go
+++ b/server/backend.go
@@ -43,7 +43,7 @@ type Backend struct {
 	Up         *Availability
 }
 
-func NewBackend(be *config.Backend) (*Backend, error) {
+func NewBackend(be config.Backend) (*Backend, error) {
 	opts := []grpc.DialOption{grpc.WithInsecure()}
 	if be.MaxMessageSize == 0 {
 		be.MaxMessageSize = 10 << 20 // default to 10MiB

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -5,8 +5,9 @@ import (
 )
 
 type Backend struct {
-	Id   string `json:"id"`
-	Addr string `json:"addr"`
+	Id             string `json:"id"`
+	Addr           string `json:"addr"`
+	MaxMessageSize int    `json:"maxMessageSize"`
 }
 
 // For more options - https://pkg.go.dev/gopkg.in/alexcesaro/statsd.v2#pkg-index

--- a/server/server.go
+++ b/server/server.go
@@ -392,7 +392,7 @@ func New(cfg *config.Config) (http.Handler, error) {
 	}
 
 	for _, bk := range srv.config.Backends {
-		be, e := NewBackend(*bk)
+		be, e := NewBackend(bk)
 		if e != nil {
 			return nil, e
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -392,7 +392,7 @@ func New(cfg *config.Config) (http.Handler, error) {
 	}
 
 	for _, bk := range srv.config.Backends {
-		be, e := NewBackend(bk.Id, bk.Addr)
+		be, e := NewBackend(*bk)
 		if e != nil {
 			return nil, e
 		}


### PR DESCRIPTION
- Add to config type to make max msg size configurable
- Slightly refactor constructor to reduce coupling
- Default to 10MiB instead of 4MiB
